### PR TITLE
fix linux build

### DIFF
--- a/Agent_DQN.h
+++ b/Agent_DQN.h
@@ -5,10 +5,6 @@
 #include "DCNN.h"
 #include "RL.h"
 
-
-
-
-
 template<int50 SIZE_PERCEPT, int50 SIZE_ACTION>
 class Agent_DQN: public Agent<SIZE_PERCEPT, SIZE_ACTION>
 {
@@ -475,7 +471,9 @@ public:
 			Sleep(0);
 		}
 #else
-
+		#if defined(__linux__) && defined(__GNUC__)
+		#define __cdecl
+		#endif
 		threadObj.join();
 #endif
 #endif

--- a/DCNN.h
+++ b/DCNN.h
@@ -1225,10 +1225,10 @@ public:
 				PrintFilters_BP(l, config[l].L_FC/2, config[l].W_FC/2, h);
 
 				double b_min = neuron[0].b;
-				for(int50 i=0; i<idx_neuron[1]; i++) b_min = min(b_min, neuron[i].b);
+				for(int50 i=0; i<idx_neuron[1]; i++) b_min = std::min(b_min, neuron[i].b);
 
 				double b_max = neuron[0].b;
-				for(int50 i=0; i<idx_neuron[1]; i++) b_max = max(b_max, neuron[i].b);
+				for(int50 i=0; i<idx_neuron[1]; i++) b_max = std::max(b_max, neuron[i].b);
 
 				for(int50 i=0; i<size_input; i++)
 				{

--- a/mnist.h
+++ b/mnist.h
@@ -48,7 +48,7 @@ void DumpImage_MNIST_Training()
 	for(int t=0; t<num_image; t++)
 	{
 		file.read((char*)data, img_size);
-		printf("file %d, read %d bytes\n", t, file.gcount());
+		printf("file %d, read %ld bytes\n", t, file.gcount());
 		assert(file);
 
 		char filename[1000];
@@ -96,7 +96,7 @@ void DumpImage_MNIST_Testing()
 	for(int t=0; t<num_image; t++)
 	{
 		file.read((char*)data, img_size);
-		printf("file %d, read %d bytes\n", t, file.gcount());
+		printf("file %d, read %ld bytes\n", t, file.gcount());
 		assert(file);
 
 		char filename[1000];
@@ -353,7 +353,7 @@ public:
                     fprintf(fp, "step #%lld \t img=%lld \t label=%lld \t output=%lld \t %s\n", timestamp-(log.size()-1)+i, log[i].data_id, log[i].label, log[i].action, (log[i].label==log[i].action)?"same":"diff");
                 }
             }
-            fprintf(fp, "accuracy in the last %lld steps  = %.2lf%%\n\n", log.size()-1, nCorrect/(double)(log.size()-1)*100);
+            fprintf(fp, "accuracy in the last %ld steps  = %.2lf%%\n\n", log.size()-1, nCorrect/(double)(log.size()-1)*100);
         }
         else assert(0);  
     }
@@ -383,8 +383,8 @@ void mnist_test()
     // create the neural network
     DCNN<SIZE_IMG, SIZE_LABEL> nn(num_parallel_learner);
 	nn.Setup(config);
-	if(nn.size_output != SIZE_LABEL) {printf("I/O mismatch: \t %lld \t %lld\n", nn.size_output, SIZE_LABEL); getchar();}
-	if(nn.size_input != SIZE_IMG) {printf("I/O mismatch: \t %lld \t %lld\n", nn.size_input, SIZE_IMG); getchar();}
+	if(nn.size_output != SIZE_LABEL) {printf("I/O mismatch: \t %lld \t %d\n", nn.size_output, SIZE_LABEL); getchar();}
+	if(nn.size_input != SIZE_IMG) {printf("I/O mismatch: \t %lld \t %d\n", nn.size_input, SIZE_IMG); getchar();}
 
 	// initialize the weights
 	if(filename_weight != NULL)

--- a/utils/PerfVar.h
+++ b/utils/PerfVar.h
@@ -26,6 +26,10 @@ double toMicroSeconds(LARGE_INTEGER endTime, LARGE_INTEGER startTime)
     return std::chrono::duration_cast<std::chrono::milliseconds>(endTime - startTime).count();
 }
 
+#if defined(__GNUC__)
+#define __cdecl
+#endif
+
 #else
 #include <windows.h>
 #include <process.h>
@@ -278,7 +282,7 @@ int PerfVar::Dump(const char* fileName, bool auto_clean)
         fprintf(fp, "%s \t ", name);
     }
 
-    fprintf(fp, "%.3lf \t %.3lf \t %.3lf \t %.3lf \t %.3lf \t %lld\n", 
+    fprintf(fp, "%.3lf \t %.3lf \t %.3lf \t %.3lf \t %.3lf \t %ld\n", 
         mean,
         deviation, 
         (number==0) ? 0 : max, 
@@ -306,7 +310,7 @@ int PerfVar::Print(FILE* fp, bool auto_clean)
         fprintf(fp, "%s \t ", name);
     }
 
-    fprintf(fp, "mean=%.3lf  dev.=%.3lf  max=%.3lf min=%.3lf total=%.3lf  number=%lld\n",
+    fprintf(fp, "mean=%.3lf  dev.=%.3lf  max=%.3lf min=%.3lf total=%.3lf  number=%ld\n",
         mean,
         deviation, 
         (number==0) ? 0 : max, 
@@ -333,7 +337,7 @@ void __cdecl CPULoad(void* argv)
 void ThroughputTest(int thread_num =1)
 {
 	FILE* fp = fopen("cputest.txt", "w");
-	fprintf(fp, "#thread \t throughput (st) \t throughput (mt) \t speedup(%)\n");
+	fprintf(fp, "#thread \t throughput (st) \t throughput (mt) \t speedup(%%)\n");
 	fflush(fp);
 
 	double throughput_st;

--- a/utils/image.h
+++ b/utils/image.h
@@ -14,7 +14,7 @@
 
 
 
-bool Mat2BMP(unsigned char* x, int row, int column, char* filename)
+bool Mat2BMP(unsigned char* x, int row, int column, const char* filename)
 {
 	BMP img;
 	img.SetSize(column,row);
@@ -32,7 +32,7 @@ bool Mat2BMP(unsigned char* x, int row, int column, char* filename)
 	return img.WriteToFile(filename);
 }
 
-bool BMP2Mat(unsigned char* x, int row, int column, char* filename)
+bool BMP2Mat(unsigned char* x, int row, int column, const char* filename)
 {
 	BMP img;
 	img.SetSize(column,row);

--- a/utils/utils.h
+++ b/utils/utils.h
@@ -182,7 +182,7 @@ public:
     FILE* fp;
 
 public:
-    FileSynchronizer(char* filename_str)
+    FileSynchronizer(const char* filename_str)
         : filename(filename_str), fp(NULL)
     {
         fp = fopen(filename.c_str(), "r");   
@@ -229,7 +229,7 @@ class Queue
 protected:
 	int50 s;
 	_T* item;
-	void* mem;
+	char* mem;
 	int50 h;
 	int50 t;
 	int50 CAPACITY;


### PR DESCRIPTION
linux build was broken yesterday because gcc doesn't accept "__cdecl"
and it needs to use std::min or std::max.

on mac, since it uses clang, I didn't see these problems.

this pull request fixes the linux build. I also got the automatic linux build pass. 